### PR TITLE
Add size to LazySearch

### DIFF
--- a/search.ts
+++ b/search.ts
@@ -197,4 +197,12 @@ export class LazySearch implements Iterator<search.Result | null> {
          value: this.currentData[this.index++]
       }
    }
+
+   /**
+    * Returns the total result count using the PagedData object's count property
+    * @returns {number}
+    */
+   size(): number {
+      return this.pagedData.count
+   }
 }


### PR DESCRIPTION
The intent here is to be able to do the following:
```typescript
const results = Seq(LazySearch(mySearch))
var totalResultCount = results.size()
```