### PR TITLE
ensure 'id' exists when you json stringify a NSDAL object

### DIFF
--- a/DataAccess/Record.js
+++ b/DataAccess/Record.js
@@ -91,7 +91,7 @@ var __extends = (this && this.__extends) || (function () {
         };
         NetsuiteCurrentRecord.prototype.toJSON = function () {
             // surface inherited properties on a new object so JSON.stringify() sees them all
-            var result = {};
+            var result = { id: this._id };
             for (var key in this) { // noinspection JSUnfilteredForInLoop
                 result[key] = this[key];
             }

--- a/DataAccess/Record.ts
+++ b/DataAccess/Record.ts
@@ -75,7 +75,7 @@ export abstract class NetsuiteCurrentRecord {
 
    toJSON () {
       // surface inherited properties on a new object so JSON.stringify() sees them all
-      const result: any = {}
+      const result: any = { id: this._id }
       for (const key in this) { // noinspection JSUnfilteredForInLoop
          result[key] = this[key]
       }

--- a/__mocks__/N/record.js
+++ b/__mocks__/N/record.js
@@ -20,7 +20,13 @@
     exports.setValue = jest.fn().mockName('setValue');
     exports.getText = jest.fn().mockName('getText');
     exports.setText = jest.fn().mockName('setText');
-    exports.load = jest.fn().mockReturnThis().mockName('load');
+    exports.load = jest.fn(function (_a) {
+        var id = _a.id, type = _a.type, isDynamic = _a.isDynamic;
+        this.id = id;
+        this.type = type;
+        this.isDynamic = isDynamic;
+        return this;
+    });
     exports.getLineCount = jest.fn().mockName('getLineCount');
     exports.getFields = jest.fn();
     exports.getField = jest.fn();

--- a/__mocks__/N/record.ts
+++ b/__mocks__/N/record.ts
@@ -4,11 +4,17 @@ export const create = jest.fn( function ( config ) {
    return this
 }).mockName('create')
 export const Type = jest.fn()
+
 export const getValue = jest.fn().mockName('getValue')
 export const setValue = jest.fn().mockName('setValue')
 export const getText = jest.fn().mockName('getText')
 export const setText = jest.fn().mockName('setText')
-export const load = jest.fn().mockReturnThis().mockName('load')
+export const load = jest.fn(function({id, type, isDynamic}) {
+   this.id = id
+   this.type = type
+   this.isDynamic = isDynamic
+   return this
+})
 export const getLineCount = jest.fn().mockName('getLineCount')
 export const getFields = jest.fn()
 export const getField = jest.fn()

--- a/test/nsdal.test.js
+++ b/test/nsdal.test.js
@@ -115,7 +115,7 @@
             expect(serializedjson).toContain('accountnumber');
             expect(serializedjson).toContain('email');
             // id should always be there.
-            expect(serializedjson).toContain('id');
+            expect(serializedjson).toMatch(/"id".?:.?"123"/);
             // JSON.stringify does not serialize undefined fields
             expect(serializedjson).not.toContain('externalid');
         });

--- a/test/nsdal.test.js
+++ b/test/nsdal.test.js
@@ -108,11 +108,14 @@
                 };
                 return v[obj.fieldId];
             });
+            console.log('customerbase', c);
             var serializedjson = JSON.stringify(c);
             console.debug(serializedjson);
             expect(serializedjson).toContain('companyname');
             expect(serializedjson).toContain('accountnumber');
             expect(serializedjson).toContain('email');
+            // id should always be there.
+            expect(serializedjson).toContain('id');
             // JSON.stringify does not serialize undefined fields
             expect(serializedjson).not.toContain('externalid');
         });

--- a/test/nsdal.test.ts
+++ b/test/nsdal.test.ts
@@ -139,7 +139,7 @@ describe('serialization', () => {
       expect(serializedjson).toContain('accountnumber')
       expect(serializedjson).toContain('email')
       // id should always be there.
-      expect(serializedjson).toContain('id')
+      expect(serializedjson).toMatch(/"id".?:.?"123"/)
       // JSON.stringify does not serialize undefined fields
       expect(serializedjson).not.toContain('externalid')
    })

--- a/test/nsdal.test.ts
+++ b/test/nsdal.test.ts
@@ -121,7 +121,6 @@ describe('body field access', function () {
 
 describe('serialization', () => {
    test('serializes to json including inherited props', function () {
-
       const c = new cust.CustomerBase('123')
       mockrecord.getValue.mockImplementation((obj) => {
          const v = {
@@ -132,13 +131,15 @@ describe('serialization', () => {
          }
          return v[obj.fieldId]
       })
-
+      console.log('customerbase', c)
       const serializedjson = JSON.stringify(c)
 
       console.debug(serializedjson)
       expect(serializedjson).toContain('companyname')
       expect(serializedjson).toContain('accountnumber')
       expect(serializedjson).toContain('email')
+      // id should always be there.
+      expect(serializedjson).toContain('id')
       // JSON.stringify does not serialize undefined fields
       expect(serializedjson).not.toContain('externalid')
    })


### PR DESCRIPTION
Noticed that currently JSON stringify only includes the protected `_id` property - whereas if we want to treat the JSON as a read-only instance of some NFT NSDAL type, it needs an `id`, not`_id`. For example, with mediator if I do a `getCustomer` command, it should return customer JSON that includes an `id`,  so I can still use the `Customer` class on the client side for property code-completion. Granted, it's not a real NSDAL object but we know on the client side  because it came from plain JSON so it's obviously not a real NSDAL record. Still useful for the shape (properties).