### PR TITLE
Add Nullable<T>

### DIFF
--- a/DataAccess/Record.js
+++ b/DataAccess/Record.js
@@ -52,7 +52,7 @@ var __extends = (this && this.__extends) || (function () {
             // pull the 'static' recordType from the derived class and remove the need for derived classes to
             // define a constructor to pass the record type to super()
             var type = Object.getPrototypeOf(this).constructor.recordType();
-            if (!rec) {
+            if (!rec) { // falsey values (e.g. invalid id 0, null, undefined, etc.) implies creating a new record
                 log.debug('creating new record', "type:" + type + "  isDyanamic:" + isDynamic + " defaultValues:" + defaultValues);
                 this.makeRecordProp(record.create({ type: type, isDynamic: isDynamic, defaultValues: defaultValues }));
             }

--- a/DataAccess/Record.ts
+++ b/DataAccess/Record.ts
@@ -11,6 +11,8 @@ import { Sublist, SublistLine } from './Sublist'
 const log = LogManager.getLogger('nsdal')
 // from https://www.typescriptlang.org/v2/docs/handbook/advanced-types.html#distributive-conditional-types
 type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
+// adds `null` as a union to type T. Use this to mark record properties as explicitly nullable
+export type Nullable<T> = T | null
 /**
  * Since the netsuite defined 'CurrentRecord' type has almost all the same operations as the normal 'Record'
  * we use this as our base class
@@ -46,12 +48,12 @@ export abstract class NetsuiteCurrentRecord {
     */
    private makeRecordProp = (value) => Object.defineProperty(this, 'nsrecord', { value: value })
 
-   constructor (rec?: number | string | record.Record | record.ClientCurrentRecord, isDynamic?: boolean, protected defaultValues?: object) {
+   constructor (rec?: null | number | string | record.Record | record.ClientCurrentRecord, isDynamic?: boolean, protected defaultValues?: object) {
       // since the context of this.constructor is the derived class we're instantiating, using the line below we can
       // pull the 'static' recordType from the derived class and remove the need for derived classes to
       // define a constructor to pass the record type to super()
       let type = Object.getPrototypeOf(this).constructor.recordType()
-      if (!rec) {
+      if (!rec) { // falsey values (e.g. invalid id 0, null, undefined, etc.) implies creating a new record
          log.debug('creating new record', `type:${type}  isDyanamic:${isDynamic} defaultValues:${defaultValues}`)
          this.makeRecordProp(record.create({ type: type, isDynamic: isDynamic, defaultValues: defaultValues }))
       } else if (typeof rec === 'object') {


### PR DESCRIPTION
As we continue to try and stengthen our types, using TypeScript's 'strictNullChecks' option means all properties on NSDAL classes _unable_ to accept `nul`. However, for NSDAL objects for most fields we DO want to support `null` because that's how we indicate _clearing a field value_. i.e. if you set it to `null` it empties the field value. So, this simple helper type is something we can start using on record classes to indicate which fields can/should be assignable to null. It really is just a shorthand for writing something like `string | null` ( same as `Nullable<string>`) but with code completion you can save keystrokes using Nullable. Also it makes it clear by name rather than thinking about union types (|). 