### PR TITLE
simplify autlogging 'details' output

### DIFF
--- a/EC_Logger.js
+++ b/EC_Logger.js
@@ -264,7 +264,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from) {
         return aop.around(methodsToLogEntryExit, function (invocation) {
             // record function entry with details for every method on our explore object
             var entryTitle = "Enter " + invocation.method + "() " + getGovernanceMessage(withGovernance);
-            var entryDetail = withArgs ? "args: " + JSON.stringify(arguments[0].arguments) : null;
+            var entryDetail = withArgs ? arguments[0].arguments : null;
             logger[level](entryTitle, entryDetail);
             var startTime = Date.now();
             var retval = invocation.proceed();
@@ -275,7 +275,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from) {
                 elapsedMessage = elapsedMilliseconds + "ms = " + elapsedMinutes + " minutes";
             }
             var exitTitle = "Exit " + invocation.method + "(): " + elapsedMessage + " " + getGovernanceMessage(withGovernance);
-            var exitDetail = withReturnValue ? "returned: " + JSON.stringify(retval) : null;
+            var exitDetail = withReturnValue ? retval : null;
             logger[level](exitTitle, exitDetail);
             return retval;
         });

--- a/EC_Logger.ts
+++ b/EC_Logger.ts
@@ -241,7 +241,7 @@ export function autoLogMethodEntryExit (methodsToLogEntryExit: { target: Object,
    return aop.around(methodsToLogEntryExit, function (invocation) {
       // record function entry with details for every method on our explore object
       const entryTitle = `Enter ${invocation.method}() ${getGovernanceMessage(withGovernance)}`
-      const entryDetail = withArgs ? `args: ${JSON.stringify(arguments[0].arguments)}` : null
+      const entryDetail = withArgs ? arguments[0].arguments : null
 
       logger[level](entryTitle, entryDetail)
 
@@ -255,7 +255,7 @@ export function autoLogMethodEntryExit (methodsToLogEntryExit: { target: Object,
       }
 
       const exitTitle = `Exit ${invocation.method}(): ${elapsedMessage} ${getGovernanceMessage(withGovernance)}`
-      const exitDetail = withReturnValue ? `returned: ${JSON.stringify(retval)}` : null
+      const exitDetail = withReturnValue ? retval : null
       logger[level](exitTitle, exitDetail)
       return retval
    })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netsuite-fasttrack-toolkit-ss2",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "Power library for NetSuite SuiteScript 2.x",
   "homepage": "https://exploreconsulting.github.io/netsuite-fasttrack-toolkit-ss2/",
   "main": "none",

--- a/test/EC_Logger.test.js
+++ b/test/EC_Logger.test.js
@@ -58,8 +58,8 @@
                 // when invoked, by default should automatically log 'Entry' and 'Exit' lines describing the invocation
                 X.dummy(4);
                 expect(fakedebug).toBeCalledTimes(2);
-                expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', 'args: [4]');
-                expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined', 'returned: 4');
+                expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', [4]);
+                expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined', 4);
             });
             it('should autolog method timing', () => {
                 const X = getTarget();
@@ -68,8 +68,8 @@
                 // when invoked, by default should automatically log 'Entry' and 'Exit' lines describing the invocation
                 X.dummy(4);
                 expect(fakedebug).toBeCalledTimes(2);
-                expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', 'args: [4]');
-                expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy(): 0ms = 0.00 minutes undefined', 'returned: 4');
+                expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', [4]);
+                expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy(): 0ms = 0.00 minutes undefined', 4);
             });
             it('should autolog for class methods', () => {
                 expect(fakedebug).not.toBeCalled();
@@ -83,8 +83,8 @@
                 // when invoked, by default should automatically log 'Entry' and 'Exit' lines describing the invocation
                 a.dummy(4);
                 expect(fakedebug).toBeCalledTimes(2);
-                expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', 'args: [4]');
-                expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined', 'returned: 4');
+                expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', [4]);
+                expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined', 4);
             });
         });
     });

--- a/test/EC_Logger.test.ts
+++ b/test/EC_Logger.test.ts
@@ -62,8 +62,8 @@ describe('basic logger tests', () => {
          X.dummy(4)
 
          expect(fakedebug).toBeCalledTimes(2)
-         expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', 'args: [4]')
-         expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined','returned: 4')
+         expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', [4])
+         expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined',4)
       })
 
       it('should autolog method timing', () => {
@@ -76,8 +76,8 @@ describe('basic logger tests', () => {
          X.dummy(4)
 
          expect(fakedebug).toBeCalledTimes(2)
-         expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', 'args: [4]')
-         expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy(): 0ms = 0.00 minutes undefined','returned: 4')
+         expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', [4])
+         expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy(): 0ms = 0.00 minutes undefined',4)
       })
 
       it('should autolog for class methods', () => {
@@ -94,8 +94,8 @@ describe('basic logger tests', () => {
          a.dummy(4)
 
          expect(fakedebug).toBeCalledTimes(2)
-         expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', 'args: [4]')
-         expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined','returned: 4')
+         expect(fakedebug).toHaveBeenNthCalledWith(1, 'DEBUG [default]', 'Enter dummy() undefined', [4])
+         expect(fakedebug).toHaveBeenLastCalledWith('DEBUG [default]', 'Exit dummy():  undefined',4)
       })
    })
 })


### PR DESCRIPTION
This removes the JSON.stringification and the prefixes added by the autologger. 
See the commit comment.