### PR TITLE
Added params callback to rescheduleIfNeeded

### DIFF
--- a/governance.ts
+++ b/governance.ts
@@ -7,7 +7,10 @@ import * as task from "N/task"
  * remaining and/or units thresholds.
  * @param startTime when to start counting elapsed time for clock-time governance, ms since the epoch (e.g. Date.now())
  * @param units threshold for minimum remaining governance units
- * @param minutes threshold for maximum number of minutes allowed to elapse
+ * @param minutes threshold for maximum number of minutes allowed to elapse.
+ *                Note: If not setting a minute value, pass {undefined} or a very high minute value. Using {null} will
+ *                      create undesired behavior (i.e., it will return false when comparing the elapsed time to null)
+ *
  * @example
  *
  * // defaults to 200 units threshold and starts elapsed time tracking at this invocation
@@ -29,6 +32,8 @@ export function governanceRemains (startTime = Date.now(), minutes = 45, units =
 /**
  * Reschedules the current script using the same deployment id if we're out of governance
  * @param params optional script parameters to provide to the newly scheduled script
+ * @param paramsCallback optional callback that will supply the params object. This can be useful if you have
+ * parameters data that is updated after the point rescheduleIfNeeded is executed.
  * @param governancePredicate governance checker - if it returns false then script will reschedule.
  * typically this would be your invocation of `governanceRemains()`
  * @example
@@ -37,18 +42,19 @@ export function governanceRemains (startTime = Date.now(), minutes = 45, units =
  * ( so it can be invoked by takeWhile() as well)
  *
  */
-export function rescheduleIfNeeded(governancePredicate: () => boolean, params?: object) {
+export function rescheduleIfNeeded(governancePredicate: () => boolean, params?: object, paramsCallback?: () => {}) {
    return () => {
       const governanceRemains = governancePredicate()
       if (!governanceRemains) {
-         log.warn('out of governance, rescheduling',
-            task.create({
-               taskType: task.TaskType.SCHEDULED_SCRIPT,
-               scriptId: runtime.getCurrentScript().id,
-               deploymentId: runtime.getCurrentScript().deploymentId,
-               params: params
-            }).submit()
-         )
+         const effectiveParams = paramsCallback ? paramsCallback() : params
+         const taskID = task.create({
+            taskType: task.TaskType.SCHEDULED_SCRIPT,
+            scriptId: runtime.getCurrentScript().id,
+            deploymentId: runtime.getCurrentScript().deploymentId,
+            params: effectiveParams
+         }).submit()
+         log.info('out of governance, rescheduling',
+            `Task ID ${taskID} with parameters ${JSON.stringify(effectiveParams)}` )
       }
       return governanceRemains
    }
@@ -70,4 +76,3 @@ export function rescheduleIfNeeded(governancePredicate: () => boolean, params?: 
 export function autoReschedule (startTime?:number, minutes?:number, units?: number) {
    return rescheduleIfNeeded(governanceRemains(startTime, minutes, units))
 }
-

--- a/test/governance.test.js
+++ b/test/governance.test.js
@@ -69,5 +69,14 @@
             // task.create() is called with our script params
             expect(mocktask.create.mock.calls[0][0]).toEqual(expect.objectContaining({ params: scriptParams }));
         });
+        test('passes callback script params when rescheduling (supersedes params:object parameter)', function () {
+            const alwaysFalse = () => false;
+            let scriptParams = { foo: 'bar' };
+            const makeScriptParams = () => scriptParams;
+            const sut = (0, governance_1.rescheduleIfNeeded)(alwaysFalse, undefined, () => makeScriptParams());
+            expect(sut()).toEqual(false);
+            // task.create() is called with our script params
+            expect(mocktask.create.mock.calls[0][0]).toEqual(expect.objectContaining({ params: scriptParams }));
+        });
     });
 });

--- a/test/governance.test.ts
+++ b/test/governance.test.ts
@@ -98,4 +98,16 @@ describe('rescheduling', function () {
       expect(mocktask.create.mock.calls[0][0]).toEqual( expect.objectContaining({params: scriptParams }) )
    })
 
+   test('passes callback script params when rescheduling (supersedes params:object parameter)', function () {
+
+      const alwaysFalse = () => false
+
+      let scriptParams = { foo: 'bar' }
+      const makeScriptParams = () =>  scriptParams
+      const sut = rescheduleIfNeeded( alwaysFalse, undefined, () => makeScriptParams() )
+
+      expect(sut()).toEqual(false)
+      // task.create() is called with our script params
+      expect(mocktask.create.mock.calls[0][0]).toEqual( expect.objectContaining({params: scriptParams }) )
+   })
 });


### PR DESCRIPTION
resolves request #86 

1. Added params callback to rescheduleIfNeeded - resolves request #86 
2. Added additional logging to rescheduleIfNeeded to report the params value
3. Added additional details to `governanceRemains()` comments, cautioning against using `null` for skipped parameters